### PR TITLE
Remove bench from CircleCI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,9 +28,6 @@ jobs:
             RUST_BACKTRACE: 1
             CACTUS_LOG: trace
       - run:
-          name: Benchmark Workspace
-          command: cargo bench || true
-      - run:
           name: Format Rust Sources
           command: |
             rustfmt --version


### PR DESCRIPTION
Bench is highly parallel, so even though it does not leak, it uses
too much CPU and memory. CircleCI was killing the step with a SIGKILL
because the step went over its resource limits.

Remove the build step.

Fixes GH-3.