### PR TITLE
Remove explicit negative Send and Sync impls

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
     alloc_layout_extra,
     box_into_raw_non_null,
     dropck_eyepatch,
-    optin_builtin_traits,
     specialization
 )]
 #![deny(warnings, intra_doc_link_resolution_failure, missing_docs)]
@@ -41,6 +40,8 @@
 //!
 //! If you do not depend on these APIs, `cactusref` is a drop-in replacement for
 //! [`std::rc`].
+//!
+//! Like [`std::rc`], [`Rc`] and [`Weak`] are `!`[`Send`] and `!`[`Sync`].
 //!
 //! ## Cycle Detection
 //!

--- a/src/rc.rs
+++ b/src/rc.rs
@@ -29,13 +29,24 @@ use crate::Weak;
 /// that you have to call them as e.g., [`Rc::get_mut(&mut value)`](Rc::get_mut)
 /// instead of `value.get_mut()`. This avoids conflicts with methods of the
 /// inner type `T`.
+///
+/// Like [`std::rc::Rc`], `Rc` is `!`[`Send`] and `!`[`Sync`].
+///
+/// ```rust,compile_fail
+/// # use cactusref::Rc;
+/// fn requires_send<T: Send>(s: T) {}
+/// requires_send(Rc::new(5));
+/// ```
+///
+/// ```rust,compile_fail
+/// # use cactusref::Rc;
+/// fn requires_sync<T: Sync>(s: T) {}
+/// requires_sync(Rc::new(5));
+/// ```
 pub struct Rc<T: ?Sized> {
     pub(crate) ptr: NonNull<RcBox<T>>,
     pub(crate) phantom: PhantomData<T>,
 }
-
-impl<T: ?Sized> !Send for Rc<T> {}
-impl<T: ?Sized> !Sync for Rc<T> {}
 
 impl<T> Rc<T> {
     /// Constructs a new `Rc<T>`.

--- a/src/weak.rs
+++ b/src/weak.rs
@@ -24,6 +24,22 @@ use crate::Rc;
 /// pointers from children back to their parents.
 ///
 /// The typical way to obtain a `Weak` pointer is to call [`Rc::downgrade`].
+///
+/// Like [`std::rc::Weak`], `Weak` is `!`[`Send`] and `!`[`Sync`].
+///
+/// ```rust,compile_fail
+/// # use cactusref::Rc;
+/// fn requires_send<T: Send>(s: T) {}
+/// let item = Rc::new(5);
+/// requires_send(Rc::downgrade(&item));
+/// ```
+///
+/// ```rust,compile_fail
+/// # use cactusref::Rc;
+/// fn requires_sync<T: Sync>(s: T) {}
+/// let item = Rc::new(5);
+/// requires_sync(Rc::downgrade(&item));
+/// ```
 pub struct Weak<T: ?Sized> {
     // This is a `NonNull` to allow optimizing the size of this type in enums,
     // but it is not necessarily a valid pointer.
@@ -32,9 +48,6 @@ pub struct Weak<T: ?Sized> {
     // will ever have because RcBox has alignment at least 2.
     pub(crate) ptr: NonNull<RcBox<T>>,
 }
-
-impl<T: ?Sized> !Send for Weak<T> {}
-impl<T: ?Sized> !Sync for Weak<T> {}
 
 impl<T> Weak<T> {
     /// Constructs a new `Weak<T>`, without allocating any memory.


### PR DESCRIPTION
Rc and Weak are already not Send and Sync because RcBox includes Cell
and RefCell members.

Remove the negative trait impls which allows removing the nightly feature
optin_builtin_traits. Add doctests to ensure that Rc and Weak are !Send
and !Sync.