### PR TITLE
Alter drop bench to only test dropping an orphaned cycle

### DIFF
--- a/benches/drop.rs
+++ b/benches/drop.rs
@@ -14,9 +14,7 @@ struct Node {
 }
 
 fn circular_graph(count: usize) -> Rc<RefCell<Node>> {
-    let first = Rc::new(RefCell::new(Node {
-        links: vec![],
-    }));
+    let first = Rc::new(RefCell::new(Node { links: vec![] }));
     let mut last = Rc::clone(&first);
     for _ in 1..count {
         let obj = Rc::new(RefCell::new(Node {
@@ -33,9 +31,7 @@ fn circular_graph(count: usize) -> Rc<RefCell<Node>> {
 fn fully_connected_graph(count: usize) -> Rc<RefCell<Node>> {
     let mut nodes = vec![];
     for _ in 0..count {
-        nodes.push(Rc::new(RefCell::new(Node {
-            links: vec![],
-        })));
+        nodes.push(Rc::new(RefCell::new(Node { links: vec![] })));
     }
     for left in &nodes {
         for right in &nodes {

--- a/benches/drop.rs
+++ b/benches/drop.rs
@@ -9,35 +9,31 @@ use criterion::black_box;
 use criterion::Criterion;
 use std::cell::RefCell;
 
-struct Node<T> {
-    _data: T,
+struct Node {
     links: Vec<Rc<RefCell<Self>>>,
 }
 
-fn circular_graph(count: usize) -> Vec<Rc<RefCell<Node<usize>>>> {
-    let mut nodes = vec![];
-    for i in 0..count {
-        nodes.push(Rc::new(RefCell::new(Node {
-            _data: i,
-            links: vec![],
-        })));
+fn circular_graph(count: usize) -> Rc<RefCell<Node>> {
+    let first = Rc::new(RefCell::new(Node {
+        links: vec![],
+    }));
+    let mut last = Rc::clone(&first);
+    for _ in 1..count {
+        let obj = Rc::new(RefCell::new(Node {
+            links: vec![Rc::clone(&last)],
+        }));
+        Rc::adopt(&obj, &last);
+        last = obj;
     }
-    for i in 0..count - 1 {
-        let link = Rc::clone(&nodes[i + 1]);
-        Rc::adopt(&nodes[i], &link);
-        nodes[i].borrow_mut().links.push(link);
-    }
-    let link = Rc::clone(&nodes[0]);
-    Rc::adopt(&nodes[count - 1], &link);
-    nodes[count - 1].borrow_mut().links.push(link);
-    nodes
+    Rc::adopt(&first, &last);
+    first.borrow_mut().links.push(Rc::clone(&last));
+    first
 }
 
-fn fully_connected_graph(count: usize) -> Vec<Rc<RefCell<Node<usize>>>> {
+fn fully_connected_graph(count: usize) -> Rc<RefCell<Node>> {
     let mut nodes = vec![];
-    for i in 0..count {
+    for _ in 0..count {
         nodes.push(Rc::new(RefCell::new(Node {
-            _data: i,
             links: vec![],
         })));
     }
@@ -48,7 +44,7 @@ fn fully_connected_graph(count: usize) -> Vec<Rc<RefCell<Node<usize>>>> {
             left.borrow_mut().links.push(link);
         }
     }
-    nodes
+    nodes.remove(0)
 }
 
 fn criterion_benchmark(c: &mut Criterion) {


### PR DESCRIPTION
The previous implementation of the drop bench passed a Vec of nodes to
the timed section. This actually tested calling drop on the Rc N + 1
times. This patch changes the setup functions to return the 'head' node
of the graph. This node is the only one in the graph that has an
external reference.

This patch also modfies node to contain no data so we are only testing
the cycle detection BFS instead of mixing that with how long it takes to
drop a usize.

## Bench Results

```
drop a circular graph/10
                        time:   [4.8181 us 4.9100 us 5.0236 us]
Found 16 outliers among 100 measurements (16.00%)
  4 (4.00%) low severe
  6 (6.00%) low mild
  4 (4.00%) high mild
  2 (2.00%) high severe
drop a circular graph/20
                        time:   [7.8571 us 8.0261 us 8.2171 us]
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low severe
  7 (7.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe
drop a circular graph/30
                        time:   [10.970 us 11.128 us 11.292 us]
Found 13 outliers among 100 measurements (13.00%)
  3 (3.00%) low severe
  3 (3.00%) low mild
  3 (3.00%) high mild
  4 (4.00%) high severe
drop a circular graph/40
                        time:   [13.964 us 14.177 us 14.390 us]
Found 12 outliers among 100 measurements (12.00%)
  12 (12.00%) low mild
drop a circular graph/50
                        time:   [15.838 us 16.184 us 16.524 us]
drop a circular graph/100
                        time:   [31.191 us 31.888 us 32.550 us]
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) low mild
  2 (2.00%) high mild

drop a fully connected graph/10
                        time:   [9.6320 us 9.8482 us 10.082 us]
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
drop a fully connected graph/20
                        time:   [24.695 us 25.380 us 26.132 us]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) low mild
drop a fully connected graph/30
                        time:   [49.003 us 50.631 us 52.303 us]
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
drop a fully connected graph/40
                        time:   [67.570 us 69.520 us 71.658 us]
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  2 (2.00%) high severe
drop a fully connected graph/50
                        time:   [103.25 us 106.82 us 110.59 us]
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
drop a fully connected graph/100
                        time:   [358.11 us 366.72 us 375.61 us]
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
```