### PR TITLE
Mark Adoptable::adopt and Adoptable::unadopt as unsafe fn

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,19 +97,27 @@ impl<T> List<T> {
         let tail = head.borrow_mut().prev.take();
         let next = head.borrow_mut().next.take();
         if let Some(ref tail) = tail {
-            Rc::unadopt(&head, &tail);
-            Rc::unadopt(&tail, &head);
+            unsafe {
+                Rc::unadopt(&head, &tail);
+                Rc::unadopt(&tail, &head);
+            }
             tail.borrow_mut().next = next.as_ref().map(Rc::clone);
             if let Some(ref next) = next {
-                Rc::adopt(tail, next);
+                unsafe {
+                    Rc::adopt(tail, next);
+                }
             }
         }
         if let Some(ref next) = next {
-            Rc::unadopt(&head, &next);
-            Rc::unadopt(&next, &head);
+            unsafe {
+                Rc::unadopt(&head, &next);
+                Rc::unadopt(&next, &head);
+            }
             next.borrow_mut().prev = tail.as_ref().map(Rc::clone);
             if let Some(ref tail) = tail {
-                Rc::adopt(next, tail);
+                unsafe {
+                    Rc::adopt(next, tail);
+                }
             }
         }
         self.head = next;
@@ -134,15 +142,19 @@ impl<T> From<Vec<T>> for List<T> {
             let next = &nodes[i + 1];
             curr.borrow_mut().next = Some(Rc::clone(next));
             next.borrow_mut().prev = Some(Rc::clone(curr));
-            Rc::adopt(curr, next);
-            Rc::adopt(next, curr);
+            unsafe {
+                Rc::adopt(curr, next);
+                Rc::adopt(next, curr);
+            }
         }
         let tail = &nodes[nodes.len() - 1];
         let head = &nodes[0];
         tail.borrow_mut().next = Some(Rc::clone(head));
         head.borrow_mut().prev = Some(Rc::clone(tail));
-        Rc::adopt(tail, head);
-        Rc::adopt(head, tail);
+        unsafe {
+            Rc::adopt(tail, head);
+            Rc::adopt(head, tail);
+        }
 
         let head = Rc::clone(head);
         Self { head: Some(head) }

--- a/benches/drop.rs
+++ b/benches/drop.rs
@@ -20,11 +20,15 @@ fn circular_graph(count: usize) -> Rc<RefCell<Node>> {
         let obj = Rc::new(RefCell::new(Node {
             links: vec![Rc::clone(&last)],
         }));
-        Rc::adopt(&obj, &last);
+        unsafe {
+            Rc::adopt(&obj, &last);
+        }
         last = obj;
     }
-    Rc::adopt(&first, &last);
     first.borrow_mut().links.push(Rc::clone(&last));
+    unsafe {
+        Rc::adopt(&first, &last);
+    }
     first
 }
 
@@ -36,8 +40,10 @@ fn fully_connected_graph(count: usize) -> Rc<RefCell<Node>> {
     for left in &nodes {
         for right in &nodes {
             let link = Rc::clone(right);
-            Rc::adopt(left, &link);
             left.borrow_mut().links.push(link);
+            unsafe {
+                Rc::adopt(left, &right);
+            }
         }
     }
     nodes.remove(0)

--- a/src/drop.rs
+++ b/src/drop.rs
@@ -57,8 +57,10 @@ unsafe impl<#[may_dangle] T: ?Sized> Drop for Rc<T> {
     /// let foo  = Rc::new(Foo(10));
     /// let foo2 = Rc::new(Foo(20));
     ///
-    /// Rc::adopt(&foo, &foo2);
-    /// Rc::adopt(&foo2, &foo);
+    /// unsafe {
+    ///     Rc::adopt(&foo, &foo2);
+    ///     Rc::adopt(&foo2, &foo);
+    /// }
     ///
     /// drop(foo);    // Doesn't print anything
     /// drop(foo2);   // Prints "dropped 10!" and "dropped 20!"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,19 +93,27 @@
 //!         let tail = head.borrow_mut().prev.take();
 //!         let next = head.borrow_mut().next.take();
 //!         if let Some(ref tail) = tail {
-//!             Rc::unadopt(&head, &tail);
-//!             Rc::unadopt(&tail, &head);
+//!             unsafe {
+//!                 Rc::unadopt(&head, &tail);
+//!                 Rc::unadopt(&tail, &head);
+//!             }
 //!             tail.borrow_mut().next = next.as_ref().map(Rc::clone);
 //!             if let Some(ref next) = next {
-//!                 Rc::adopt(tail, next);
+//!                 unsafe {
+//!                     Rc::adopt(tail, next);
+//!                 }
 //!             }
 //!         }
 //!         if let Some(ref next) = next {
-//!             Rc::unadopt(&head, &next);
-//!             Rc::unadopt(&next, &head);
+//!             unsafe {
+//!                 Rc::unadopt(&head, &next);
+//!                 Rc::unadopt(&next, &head);
+//!             }
 //!             next.borrow_mut().prev = tail.as_ref().map(Rc::clone);
 //!             if let Some(ref tail) = tail {
-//!                 Rc::adopt(next, tail);
+//!                 unsafe {
+//!                     Rc::adopt(next, tail);
+//!                 }
 //!             }
 //!         }
 //!         self.head = next;
@@ -130,15 +138,19 @@
 //!             let next = &nodes[i + 1];
 //!             curr.borrow_mut().next = Some(Rc::clone(next));
 //!             next.borrow_mut().prev = Some(Rc::clone(curr));
-//!             Rc::adopt(curr, next);
-//!             Rc::adopt(next, curr);
+//!             unsafe {
+//!                 Rc::adopt(curr, next);
+//!                 Rc::adopt(next, curr);
+//!             }
 //!         }
 //!         let tail = &nodes[nodes.len() - 1];
 //!         let head = &nodes[0];
 //!         tail.borrow_mut().next = Some(Rc::clone(head));
 //!         head.borrow_mut().prev = Some(Rc::clone(tail));
-//!         Rc::adopt(tail, head);
-//!         Rc::adopt(head, tail);
+//!         unsafe {
+//!             Rc::adopt(tail, head);
+//!             Rc::adopt(head, tail);
+//!         }
 //!
 //!         let head = Rc::clone(head);
 //!         Self { head: Some(head) }

--- a/tests/leak_adopt_self.rs
+++ b/tests/leak_adopt_self.rs
@@ -23,14 +23,16 @@ fn leak_adopt_self() {
             link: None,
         }));
         first.borrow_mut().link = Some(Rc::clone(&first));
-        Rc::adopt(&first, &first);
-        Rc::adopt(&first, &first);
-        Rc::adopt(&first, &first);
-        Rc::adopt(&first, &first);
-        Rc::adopt(&first, &first);
-        Rc::adopt(&first, &first);
-        Rc::adopt(&first, &first);
-        Rc::adopt(&first, &first);
+        unsafe {
+            Rc::adopt(&first, &first);
+            Rc::adopt(&first, &first);
+            Rc::adopt(&first, &first);
+            Rc::adopt(&first, &first);
+            Rc::adopt(&first, &first);
+            Rc::adopt(&first, &first);
+            Rc::adopt(&first, &first);
+            Rc::adopt(&first, &first);
+        }
         assert_eq!(first.borrow().inner, s);
         drop(first);
     });

--- a/tests/leak_adopt_with_dropped_rc.rs
+++ b/tests/leak_adopt_with_dropped_rc.rs
@@ -16,10 +16,14 @@ fn leak_adopt_with_dropped_rc() {
         let mut last = Rc::clone(&first);
         for _ in 1..10 {
             let obj = Rc::new(s.clone());
-            Rc::adopt(&obj, &last);
+            unsafe {
+                Rc::adopt(&obj, &last);
+            }
             last = obj;
         }
-        Rc::adopt(&first, &last);
+        unsafe {
+            Rc::adopt(&first, &last);
+        }
         drop(first);
         drop(last);
     });

--- a/tests/leak_adopt_with_members_in_multiple_cycles.rs
+++ b/tests/leak_adopt_with_members_in_multiple_cycles.rs
@@ -16,23 +16,33 @@ fn leak_adopt_with_members_in_multiple_cycles() {
         let mut last = Rc::clone(&first);
         for _ in 1..10 {
             let obj = Rc::new(s.clone());
-            Rc::adopt(&obj, &last);
+            unsafe {
+                Rc::adopt(&obj, &last);
+            }
             last = obj;
         }
-        Rc::adopt(&first, &last);
+        unsafe {
+            Rc::adopt(&first, &last);
+        }
         let group1 = first;
         let first = Rc::new(s.clone());
         let mut last = Rc::clone(&first);
         for _ in 101..110 {
             let obj = Rc::new(s.clone());
-            Rc::adopt(&obj, &last);
+            unsafe {
+                Rc::adopt(&obj, &last);
+            }
             last = obj;
         }
-        Rc::adopt(&first, &last);
+        unsafe {
+            Rc::adopt(&first, &last);
+        }
         let group2 = first;
         // join the two cycles
-        Rc::adopt(&group2, &group1);
-        Rc::adopt(&group1, &group2);
+        unsafe {
+            Rc::adopt(&group2, &group1);
+            Rc::adopt(&group1, &group2);
+        }
         drop(last);
         drop(group2);
         drop(group1);

--- a/tests/leak_doubly_linked_list.rs
+++ b/tests/leak_doubly_linked_list.rs
@@ -24,19 +24,27 @@ impl<T> List<T> {
         let tail = head.borrow_mut().prev.take();
         let next = head.borrow_mut().next.take();
         if let Some(ref tail) = tail {
-            Rc::unadopt(&head, &tail);
-            Rc::unadopt(&tail, &head);
+            unsafe {
+                Rc::unadopt(&head, &tail);
+                Rc::unadopt(&tail, &head);
+            }
             tail.borrow_mut().next = next.as_ref().map(Rc::clone);
             if let Some(ref next) = next {
-                Rc::adopt(tail, next);
+                unsafe {
+                    Rc::adopt(tail, next);
+                }
             }
         }
         if let Some(ref next) = next {
-            Rc::unadopt(&head, &next);
-            Rc::unadopt(&next, &head);
+            unsafe {
+                Rc::unadopt(&head, &next);
+                Rc::unadopt(&next, &head);
+            }
             next.borrow_mut().prev = tail.as_ref().map(Rc::clone);
             if let Some(ref tail) = tail {
-                Rc::adopt(next, tail);
+                unsafe {
+                    Rc::adopt(next, tail);
+                }
             }
         }
         self.head = next;
@@ -61,15 +69,19 @@ impl<T> From<Vec<T>> for List<T> {
             let next = &nodes[i + 1];
             curr.borrow_mut().next = Some(Rc::clone(next));
             next.borrow_mut().prev = Some(Rc::clone(curr));
-            Rc::adopt(curr, next);
-            Rc::adopt(next, curr);
+            unsafe {
+                Rc::adopt(curr, next);
+                Rc::adopt(next, curr);
+            }
         }
         let tail = &nodes[nodes.len() - 1];
         let head = &nodes[0];
         tail.borrow_mut().next = Some(Rc::clone(head));
         head.borrow_mut().prev = Some(Rc::clone(tail));
-        Rc::adopt(tail, head);
-        Rc::adopt(head, tail);
+        unsafe {
+            Rc::adopt(tail, head);
+            Rc::adopt(head, tail);
+        }
 
         let head = Rc::clone(head);
         Self { head: Some(head) }

--- a/tests/leak_fully_connected_graph.rs
+++ b/tests/leak_fully_connected_graph.rs
@@ -23,7 +23,9 @@ fn fully_connected_graph(count: usize) -> Vec<Rc<RefCell<Node<String>>>> {
     for left in &nodes {
         for right in &nodes {
             let link = Rc::clone(right);
-            Rc::adopt(left, &link);
+            unsafe {
+                Rc::adopt(left, &link);
+            }
             left.borrow_mut().links.push(link);
         }
     }

--- a/tests/leak_mutually_adopted.rs
+++ b/tests/leak_mutually_adopted.rs
@@ -1,7 +1,7 @@
 #![deny(clippy::all, clippy::pedantic)]
 #![deny(warnings, intra_doc_link_resolution_failure)]
 
-use cactusref::{Adoptable, CactusRef};
+use cactusref::{Adoptable, Rc};
 
 mod leak;
 
@@ -12,10 +12,12 @@ fn leak_mutually_adopted() {
     let s = "a".repeat(1024 * 1024);
 
     leak::Detector::new("mutually adopted", None, None).check_leaks(|_| {
-        let first = CactusRef::new(s.clone());
-        let last = CactusRef::new(s.clone());
-        CactusRef::adopt(&first, &last);
-        CactusRef::adopt(&last, &first);
+        let first = Rc::new(s.clone());
+        let last = Rc::new(s.clone());
+        unsafe {
+            Rc::adopt(&first, &last);
+            Rc::adopt(&last, &first);
+        }
         drop(first);
         drop(last);
     });

--- a/tests/leak_self_referential_collection_strong.rs
+++ b/tests/leak_self_referential_collection_strong.rs
@@ -24,7 +24,9 @@ fn leak_self_referential_collection_strong() {
         }));
         for _ in 1..10 {
             vec.borrow_mut().inner.push(Rc::clone(&vec));
-            Rc::adopt(&vec, &vec);
+            unsafe {
+                Rc::adopt(&vec, &vec);
+            }
         }
         drop(vec);
     });

--- a/tests/leak_self_referential_collection_weak.rs
+++ b/tests/leak_self_referential_collection_weak.rs
@@ -25,7 +25,9 @@ fn leak_self_referential_collection_weak() {
         }));
         for _ in 1..10 {
             vec.borrow_mut().inner.push(Rc::downgrade(&vec));
-            Rc::adopt(&vec, &vec);
+            unsafe {
+                Rc::adopt(&vec, &vec);
+            }
         }
         drop(vec);
     });

--- a/tests/weak.rs
+++ b/tests/weak.rs
@@ -16,7 +16,9 @@ fn weak() {
     let array = Rc::new(RefCell::new(Array::default()));
     for _ in 0..10 {
         let item = Rc::clone(&array);
-        Rc::adopt(&array, &item);
+        unsafe {
+            Rc::adopt(&array, &item);
+        }
         array.borrow_mut().buffer.push(item);
     }
     assert_eq!(Rc::strong_count(&array), 11);

--- a/tests/weak_upgrade_returns_none_when_cycle_is_deallocated.rs
+++ b/tests/weak_upgrade_returns_none_when_cycle_is_deallocated.rs
@@ -24,7 +24,9 @@ fn weak_upgrade_returns_none_when_cycle_is_deallocated() {
         }));
         for _ in 0..10 {
             vec.borrow_mut().inner.push(Rc::clone(&vec));
-            Rc::adopt(&vec, &vec);
+            unsafe {
+                Rc::adopt(&vec, &vec);
+            }
         }
         assert_eq!(Rc::strong_count(&vec), 11);
         let weak = Rc::downgrade(&vec);


### PR DESCRIPTION
Improper use can cause use-after-free because a cycle of `Rc`s may be deallocated early and create dangling pointers.

Add a best-effort abort in case access to a dead `Rc` occurs.