### PR TITLE
Update docs to clarify matrurity and goals around cycle detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,21 @@ drop(right);
 // All members of the ring are garbage collected and deallocated.
 ```
 
+## Maturity
+
+CactusRef is experimental. This crate has several limitations:
+
+- CactusRef is nightly only.
+- CactusRef reimplements several `alloc` internals which means it may not be
+  safe to use on newer nightly versions than `nightly-2021-06-13`.
+- Cycle detection requires [unsafe code][adopt-api] to use.
+
+CactusRef is a non-trivial extension to `std::rc::Rc` and has not been proven to
+be safe. Although CactusRef makes a best effort to abort the program if it
+detects a dangling `Rc`, this crate may be unsound.
+
+[adopt-api]: https://docs.rs/cactusref/*/cactusref/trait.Adopt.html
+
 ## License
 
 CactusRef is licensed with the [MIT License](LICENSE) (c) Ryan Lopopolo.

--- a/src/drop.rs
+++ b/src/drop.rs
@@ -21,8 +21,8 @@ unsafe impl<#[may_dangle] T> Drop for Rc<T> {
     /// orphaned cycle is a cycle in which all members have no owned references
     /// held by `Rc`s outside of the cycle.
     ///
-    /// Cycle detection is a zero-cost abstraction. `Rc`s do not pay the cost of
-    /// the reachability check unless they use [`Adopt::adopt`].
+    /// `Rc`s do not pay the cost of the reachability check unless they use
+    /// [`Adopt::adopt`].
     ///
     /// [`Adopt::adopt`]: crate::Adopt::adopt
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,8 @@
 //! [`clone`]: Clone::clone
 //!
 //! `Rc` can **detect and deallocate cycles** of `Rc`s through the use of
-//! [`Adopt`]. Cycle detection is a zero-cost abstraction.
+//! [`Adopt`]. Cycle detection is opt-in and no reachability checks are
+//! performed unless graphs have adoptions.
 //!
 //! # Nightly
 //!
@@ -43,6 +44,21 @@
 //! nightly compiler as the one pinned in its `rust-toolchain` file.
 //!
 //! [alloc]: https://doc.rust-lang.org/stable/alloc/
+//!
+//! # Maturity
+//!
+//! CactusRef is experimental. This crate has several limitations:
+//!
+//! - CactusRef is nightly only.
+//! - CactusRef reimplements several `alloc` internals which means it may not be
+//!   safe to use on newer nightly versions than `nightly-2021-06-13`.
+//! - Cycle detection requires [unsafe code][adopt-api] to use.
+//!
+//! CactusRef is a non-trivial extension to `std::rc::Rc` and has not been
+//! proven to be safe. Although CactusRef makes a best effort to abort the
+//! program if it detects a dangling `Rc`, this crate may be unsound.
+//!
+//! [adopt-api]: crate::Adopt
 //!
 //! # CactusRef vs. `std::rc`
 //!


### PR DESCRIPTION
Note that CactusRef is experimental and potentially unsound. Update 'zero-cost
abstraction' copy to instead note that cycle detection is opt in and has
no performance impact if Adopt is not used.

I posted this crate in the Crate of the Week thread on users.rust-lang-org and got some feedback: https://users.rust-lang.org/t/crate-of-the-week/2704/924?u=lopopolo.