### PR TITLE
Add tests to ensure crate version numbers are properly updated on release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,8 @@ log = "0.4.6"
 rustc-hash = { version = "1.1", default-features = false }
 
 [dev-dependencies]
+# Enable debug and trace-level logging in tests.
 env_logger = { version = "0.8.4", default-features = false }
+# Check that crate versions are properly updated in documentation and code when
+# bumping the version.
+version-sync = "0.9, >= 0.9.2"

--- a/tests/version_numbers.rs
+++ b/tests/version_numbers.rs
@@ -1,0 +1,9 @@
+#[test]
+fn test_readme_deps() {
+    version_sync::assert_markdown_deps_updated!("README.md");
+}
+
+#[test]
+fn test_html_root_url() {
+    version_sync::assert_html_root_url_updated!("src/lib.rs");
+}

--- a/tests/version_numbers.rs
+++ b/tests/version_numbers.rs
@@ -1,9 +1,11 @@
 #[test]
+#[cfg(not(miri))]
 fn test_readme_deps() {
     version_sync::assert_markdown_deps_updated!("README.md");
 }
 
 #[test]
+#[cfg(not(miri))]
 fn test_html_root_url() {
     version_sync::assert_html_root_url_updated!("src/lib.rs");
 }


### PR DESCRIPTION
Uses `version-sync` crate.