### PR TITLE
Prepare for v0.1.1 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cactusref"
-version = "0.1.0" # remember to set `html_root_url` in `src/lib.rs`.
+version = "0.1.1" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT"
 edition = "2018"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,7 +125,7 @@
 //!
 //! [`std::rc::Rc`]: https://doc.rust-lang.org/stable/std/rc/struct.Rc.html
 
-#![doc(html_root_url = "https://docs.rs/cactusref/0.1.0")]
+#![doc(html_root_url = "https://docs.rs/cactusref/0.1.1")]
 
 // Ensure code blocks in README.md compile
 #[cfg(doctest)]


### PR DESCRIPTION
Release 0.1.1 of CactusRef.

[`cactusref` is available on crates.io](https://crates.io/crates/cactusref/0.1.1).

CactusRef is a cycle-aware reference counting smart pointer that is a near drop-in replacement for `std::rc::Rc`.

CactusRef requires a nightly compiler.

v0.1.1 includes improvements to documentation on this crate's experimental status #40.