### PR TITLE
Rename unsafe fn Adopt::adopt to Adopt::adopt_unchecked

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,14 +88,14 @@ let right = Rc::new(RefCell::new(right));
 
 unsafe {
     // bookkeep that `right` has added an owning ref to `left`.
-    Rc::adopt(&right, &left);
+    Rc::adopt_unchecked(&right, &left);
 }
 
 left.borrow_mut().next = Some(Rc::clone(&right));
 
 unsafe {
     // bookkeep that `left` has added an owning ref to `right`.
-    Rc::adopt(&left, &right);
+    Rc::adopt_unchecked(&left, &right);
 }
 
 let mut node = Rc::clone(&left);

--- a/benchmarks/benches/drop.rs
+++ b/benchmarks/benches/drop.rs
@@ -28,7 +28,7 @@ fn chain_with_adoptions(count: usize) -> Rc<RefCell<Node>> {
             links: vec![Rc::clone(&last)],
         }));
         unsafe {
-            Rc::adopt(&obj, &last);
+            Rc::adopt_unchecked(&obj, &last);
         }
         last = obj;
     }
@@ -43,13 +43,13 @@ fn circular_graph(count: usize) -> Rc<RefCell<Node>> {
             links: vec![Rc::clone(&last)],
         }));
         unsafe {
-            Rc::adopt(&obj, &last);
+            Rc::adopt_unchecked(&obj, &last);
         }
         last = obj;
     }
     first.borrow_mut().links.push(Rc::clone(&last));
     unsafe {
-        Rc::adopt(&first, &last);
+        Rc::adopt_unchecked(&first, &last);
     }
     first
 }
@@ -64,7 +64,7 @@ fn fully_connected_graph(count: usize) -> Rc<RefCell<Node>> {
             let link = Rc::clone(right);
             left.borrow_mut().links.push(link);
             unsafe {
-                Rc::adopt(left, &right);
+                Rc::adopt_unchecked(left, &right);
             }
         }
     }

--- a/doc/cactus-harvesting.md
+++ b/doc/cactus-harvesting.md
@@ -119,7 +119,7 @@ impl<T> List<T> {
             Rc::unadopt(&tail, &head);
             tail.borrow_mut().next = next.as_ref().map(Rc::clone);
             if let Some(ref next) = next {
-                Rc::adopt(tail, next);
+                Rc::adopt_unchecked(tail, next);
             }
         }
         if let Some(ref next) = next {
@@ -127,7 +127,7 @@ impl<T> List<T> {
             Rc::unadopt(&next, &head);
             next.borrow_mut().prev = tail.as_ref().map(Rc::clone);
             if let Some(ref tail) = tail {
-                Rc::adopt(next, tail);
+                Rc::adopt_unchecked(next, tail);
             }
         }
         self.head = next;
@@ -152,15 +152,15 @@ impl<T> From<Vec<T>> for List<T> {
             let next = &nodes[i + 1];
             curr.borrow_mut().next = Some(Rc::clone(next));
             next.borrow_mut().prev = Some(Rc::clone(curr));
-            Rc::adopt(curr, next);
-            Rc::adopt(next, curr);
+            Rc::adopt_unchecked(curr, next);
+            Rc::adopt_unchecked(next, curr);
         }
         let tail = &nodes[nodes.len() - 1];
         let head = &nodes[0];
         tail.borrow_mut().next = Some(Rc::clone(head));
         head.borrow_mut().prev = Some(Rc::clone(tail));
-        Rc::adopt(tail, head);
-        Rc::adopt(head, tail);
+        Rc::adopt_unchecked(tail, head);
+        Rc::adopt_unchecked(head, tail);
 
         let head = Rc::clone(head);
         Self { head: Some(head) }

--- a/src/adopt.rs
+++ b/src/adopt.rs
@@ -15,8 +15,8 @@ mod sealed {
 /// Build a graph of linked [`Rc`] smart pointers to enable busting cycles on
 /// drop.
 ///
-/// Calling [`adopt`] builds an object graph which can be used by to detect
-/// cycles.
+/// Calling [`adopt_unchecked`] builds an object graph which can be used by to
+/// detect cycles.
 ///
 /// # Safety
 ///
@@ -31,7 +31,7 @@ mod sealed {
 /// - Double-frees.
 /// - Dangling `Rc`s which will cause a use after free.`
 ///
-/// [`adopt`]: Adopt::adopt
+/// [`adopt_unchecked`]: Adopt::adopt_unchecked
 /// [undefined behavior]: https://doc.rust-lang.org/reference/behavior-considered-undefined.html
 pub unsafe trait Adopt: sealed::Sealed {
     /// Perform bookkeeping to record that `this` has an owned reference to

--- a/src/adopt.rs
+++ b/src/adopt.rs
@@ -44,7 +44,7 @@ pub unsafe trait Adopt: sealed::Sealed {
     /// `adopt` indicates that `this` owns one distinct clone of `other`.
     ///
     /// This is an associated function that needs to be used as
-    /// `Adopt::adopt(...)`. A method would interfere with methods of the same
+    /// `Adopt::adopt_unchecked(...)`. A method would interfere with methods of the same
     /// name on the contents of a `Rc` used through `Deref`.
     ///
     /// # Safety
@@ -55,7 +55,7 @@ pub unsafe trait Adopt: sealed::Sealed {
     /// reference to `other`.
     ///
     /// [`unadopt`]: Adopt::unadopt
-    unsafe fn adopt(this: &Self, other: &Self);
+    unsafe fn adopt_unchecked(this: &Self, other: &Self);
 
     /// Perform bookkeeping to record that `this` has removed an owned reference
     /// to `other`.
@@ -73,7 +73,7 @@ pub unsafe trait Adopt: sealed::Sealed {
     /// `other`.
     ///
     /// For each call to `Adopt::unadopt(&this, &other)`, callers must ensure
-    /// that a matching call was made to `Adopt::adopt(&this, &other)`.
+    /// that a matching call was made to `Adopt::adopt_unchecked(&this, &other)`.
     unsafe fn unadopt(this: &Self, other: &Self);
 }
 
@@ -90,7 +90,7 @@ unsafe impl<T> Adopt for Rc<T> {
     /// `adopt` indicates that `this` owns one distinct clone of `other`.
     ///
     /// This is an associated function that needs to be used as
-    /// `Rc::adopt(...)`. A method would interfere with methods of the same
+    /// `Rc::adopt_unchecked(...)`. A method would interfere with methods of the same
     /// name on the contents of a `Rc` used through `Deref`.
     ///
     /// # Safety
@@ -121,7 +121,7 @@ unsafe impl<T> Adopt for Rc<T> {
     /// for _ in 0..10 {
     ///     let item = Rc::clone(&array);
     ///     unsafe {
-    ///         Rc::adopt(&array, &item);
+    ///         Rc::adopt_unchecked(&array, &item);
     ///     }
     ///     array.borrow_mut().buffer.push(item);
     /// }
@@ -134,7 +134,7 @@ unsafe impl<T> Adopt for Rc<T> {
     /// ```
     ///
     /// [`unadopt`]: Rc::unadopt
-    unsafe fn adopt(this: &Self, other: &Self) {
+    unsafe fn adopt_unchecked(this: &Self, other: &Self) {
         // Self-adoptions have no effect.
         if ptr::eq(this, other) {
             // Store a forward reference to `other` in `this`. This bookkeeping logs
@@ -173,7 +173,7 @@ unsafe impl<T> Adopt for Rc<T> {
     /// `other`.
     ///
     /// For each call to `Adopt::unadopt(&this, &other)`, callers must ensure
-    /// that a matching call was made to `Adopt::adopt(&this, &other)`.
+    /// that a matching call was made to `Adopt::adopt_unchecked(&this, &other)`.
     ///
     /// This crate makes a best-effort attempt to abort the program if an access
     /// to a dangling `Rc` occurs.
@@ -195,7 +195,7 @@ unsafe impl<T> Adopt for Rc<T> {
     /// for _ in 0..10 {
     ///     let item = Rc::clone(&array);
     ///     unsafe {
-    ///         Rc::adopt(&array, &item);
+    ///         Rc::adopt_unchecked(&array, &item);
     ///     }
     ///     array.borrow_mut().buffer.push(item);
     /// }

--- a/src/doc/implementing_self_referential_data_structures.rs
+++ b/src/doc/implementing_self_referential_data_structures.rs
@@ -35,7 +35,7 @@
 //!             tail.borrow_mut().next = next.as_ref().map(Rc::clone);
 //!             if let Some(ref next) = next {
 //!                 unsafe {
-//!                     Rc::adopt(tail, next);
+//!                     Rc::adopt_unchecked(tail, next);
 //!                 }
 //!             }
 //!         }
@@ -47,7 +47,7 @@
 //!             next.borrow_mut().prev = tail.as_ref().map(Rc::clone);
 //!             if let Some(ref tail) = tail {
 //!                 unsafe {
-//!                     Rc::adopt(next, tail);
+//!                     Rc::adopt_unchecked(next, tail);
 //!                 }
 //!             }
 //!         }
@@ -74,8 +74,8 @@
 //!             curr.borrow_mut().next = Some(Rc::clone(next));
 //!             next.borrow_mut().prev = Some(Rc::clone(curr));
 //!             unsafe {
-//!                 Rc::adopt(curr, next);
-//!                 Rc::adopt(next, curr);
+//!                 Rc::adopt_unchecked(curr, next);
+//!                 Rc::adopt_unchecked(next, curr);
 //!             }
 //!         }
 //!         let tail = &nodes[nodes.len() - 1];
@@ -83,8 +83,8 @@
 //!         tail.borrow_mut().next = Some(Rc::clone(head));
 //!         head.borrow_mut().prev = Some(Rc::clone(tail));
 //!         unsafe {
-//!             Rc::adopt(tail, head);
-//!             Rc::adopt(head, tail);
+//!             Rc::adopt_unchecked(tail, head);
+//!             Rc::adopt_unchecked(head, tail);
 //!         }
 //!
 //!         let head = Rc::clone(head);

--- a/src/drop.rs
+++ b/src/drop.rs
@@ -22,9 +22,9 @@ unsafe impl<#[may_dangle] T> Drop for Rc<T> {
     /// held by `Rc`s outside of the cycle.
     ///
     /// `Rc`s do not pay the cost of the reachability check unless they use
-    /// [`Adopt::adopt`].
+    /// [`Adopt::adopt_unchecked`].
     ///
-    /// [`Adopt::adopt`]: crate::Adopt::adopt
+    /// [`Adopt::adopt_unchecked`]: crate::Adopt::adopt_unchecked
     ///
     /// # Examples
     ///
@@ -71,19 +71,19 @@ unsafe impl<#[may_dangle] T> Drop for Rc<T> {
     ///
     /// # Cycle Detection and Deallocation Algorithm
     ///
-    /// [`Rc::adopt`] does explicit bookkeeping to store links to adoptee `Rc`s.
-    /// These links form a graph of reachable objects which are used to detect
-    /// cycles.
+    /// [`Rc::adopt_unchecked`] does explicit bookkeeping to store links to
+    /// adoptee `Rc`s.  These links form a graph of reachable objects which are
+    /// used to detect cycles.
     ///
-    /// [`Rc::adopt`]: crate::Rc::adopt
+    /// [`Rc::adopt_unchecked`]: crate::Rc::adopt_unchecked
     ///
     /// On drop, if an `Rc` has no links, it is dropped like a normal `Rc`. If
     /// the `Rc` has links, `Drop` performs a breadth first search by traversing
     /// the forward and backward links stored in each `Rc`. Deallocating cycles
-    /// requires correct use of [`Adopt::adopt`] and [`Adopt::unadopt`] to
-    /// perform the reachability bookkeeping.
+    /// requires correct use of [`Adopt::adopt_unchecked`] and [`Adopt::unadopt`]
+    /// to perform the reachability bookkeeping.
     ///
-    /// [`Adopt::adopt`]: crate::Adopt::adopt
+    /// [`Adopt::adopt_unchecked`]: crate::Adopt::adopt_unchecked
     /// [`Adopt::unadopt`]: crate::Adopt::unadopt
     ///
     /// After determining all reachable objects, `Rc` reduces the graph to

--- a/src/drop.rs
+++ b/src/drop.rs
@@ -61,8 +61,8 @@ unsafe impl<#[may_dangle] T> Drop for Rc<T> {
     /// let foo2 = Rc::new(Foo(20));
     ///
     /// unsafe {
-    ///     Rc::adopt(&foo, &foo2);
-    ///     Rc::adopt(&foo2, &foo);
+    ///     Rc::adopt_unchecked(&foo, &foo2);
+    ///     Rc::adopt_unchecked(&foo2, &foo);
     /// }
     ///
     /// drop(foo);    // Doesn't print anything

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@
 //! can deallocate a cycle of strong references that is otherwise unreachable
 //! from the rest of the object graph, unlike [`std::rc::Rc`].
 //!
-//! `CactusRef` relies on proper use of [`Adopt::adopt`] and [`Adopt::unadopt`]
+//! `CactusRef` relies on proper use of [`Adopt::adopt_unchecked`] and [`Adopt::unadopt`]
 //! to maintain bookkeeping about the object graph for breaking cycles. These
 //! functions are unsafe because improperly managing the bookkeeping can cause
 //! the `Rc` drop implementation to deallocate cycles while they are still

--- a/tests/leak_adopt_self.rs
+++ b/tests/leak_adopt_self.rs
@@ -23,14 +23,14 @@ fn leak_adopt_self() {
     }));
     let clone = Rc::clone(&first);
     unsafe {
-        Rc::adopt(&first, &clone);
-        Rc::adopt(&first, &clone);
-        Rc::adopt(&first, &clone);
-        Rc::adopt(&first, &clone);
-        Rc::adopt(&first, &clone);
-        Rc::adopt(&first, &clone);
-        Rc::adopt(&first, &clone);
-        Rc::adopt(&first, &clone);
+        Rc::adopt_unchecked(&first, &clone);
+        Rc::adopt_unchecked(&first, &clone);
+        Rc::adopt_unchecked(&first, &clone);
+        Rc::adopt_unchecked(&first, &clone);
+        Rc::adopt_unchecked(&first, &clone);
+        Rc::adopt_unchecked(&first, &clone);
+        Rc::adopt_unchecked(&first, &clone);
+        Rc::adopt_unchecked(&first, &clone);
     }
     first.borrow_mut().link = Some(clone);
     assert_eq!(first.borrow().inner, s);

--- a/tests/leak_adopt_self_noop.rs
+++ b/tests/leak_adopt_self_noop.rs
@@ -22,14 +22,14 @@ fn adopt_self_noop() {
         link: None,
     }));
     unsafe {
-        Rc::adopt(&first, &first);
-        Rc::adopt(&first, &first);
-        Rc::adopt(&first, &first);
-        Rc::adopt(&first, &first);
-        Rc::adopt(&first, &first);
-        Rc::adopt(&first, &first);
-        Rc::adopt(&first, &first);
-        Rc::adopt(&first, &first);
+        Rc::adopt_unchecked(&first, &first);
+        Rc::adopt_unchecked(&first, &first);
+        Rc::adopt_unchecked(&first, &first);
+        Rc::adopt_unchecked(&first, &first);
+        Rc::adopt_unchecked(&first, &first);
+        Rc::adopt_unchecked(&first, &first);
+        Rc::adopt_unchecked(&first, &first);
+        Rc::adopt_unchecked(&first, &first);
     }
     assert_eq!(first.borrow().inner, s);
     assert!(first.borrow().link.is_none());

--- a/tests/leak_adopt_with_dropped_rc.rs
+++ b/tests/leak_adopt_with_dropped_rc.rs
@@ -16,12 +16,12 @@ fn leak_adopt_with_dropped_rc() {
     for _ in 1..10 {
         let obj = Rc::new(s.clone());
         unsafe {
-            Rc::adopt(&obj, &last);
+            Rc::adopt_unchecked(&obj, &last);
         }
         last = obj;
     }
     unsafe {
-        Rc::adopt(&first, &last);
+        Rc::adopt_unchecked(&first, &last);
     }
     drop(first);
     drop(last);

--- a/tests/leak_adopt_with_members_in_multiple_cycles.rs
+++ b/tests/leak_adopt_with_members_in_multiple_cycles.rs
@@ -16,12 +16,12 @@ fn leak_adopt_with_members_in_multiple_cycles() {
     for _ in 1..10 {
         let obj = Rc::new(s.clone());
         unsafe {
-            Rc::adopt(&obj, &last);
+            Rc::adopt_unchecked(&obj, &last);
         }
         last = obj;
     }
     unsafe {
-        Rc::adopt(&first, &last);
+        Rc::adopt_unchecked(&first, &last);
     }
     let group1 = first;
     let first = Rc::new(s.clone());
@@ -29,18 +29,18 @@ fn leak_adopt_with_members_in_multiple_cycles() {
     for _ in 101..110 {
         let obj = Rc::new(s.clone());
         unsafe {
-            Rc::adopt(&obj, &last);
+            Rc::adopt_unchecked(&obj, &last);
         }
         last = obj;
     }
     unsafe {
-        Rc::adopt(&first, &last);
+        Rc::adopt_unchecked(&first, &last);
     }
     let group2 = first;
     // join the two cycles
     unsafe {
-        Rc::adopt(&group2, &group1);
-        Rc::adopt(&group1, &group2);
+        Rc::adopt_unchecked(&group2, &group1);
+        Rc::adopt_unchecked(&group1, &group2);
     }
     drop(last);
     drop(group2);

--- a/tests/leak_doubly_linked_list.rs
+++ b/tests/leak_doubly_linked_list.rs
@@ -29,7 +29,7 @@ impl<T> List<T> {
             tail.borrow_mut().next = next.as_ref().map(Rc::clone);
             if let Some(ref next) = next {
                 unsafe {
-                    Rc::adopt(tail, next);
+                    Rc::adopt_unchecked(tail, next);
                 }
             }
         }
@@ -41,7 +41,7 @@ impl<T> List<T> {
             next.borrow_mut().prev = tail.as_ref().map(Rc::clone);
             if let Some(ref tail) = tail {
                 unsafe {
-                    Rc::adopt(next, tail);
+                    Rc::adopt_unchecked(next, tail);
                 }
             }
         }
@@ -68,8 +68,8 @@ impl<T> From<Vec<T>> for List<T> {
             curr.borrow_mut().next = Some(Rc::clone(next));
             next.borrow_mut().prev = Some(Rc::clone(curr));
             unsafe {
-                Rc::adopt(curr, next);
-                Rc::adopt(next, curr);
+                Rc::adopt_unchecked(curr, next);
+                Rc::adopt_unchecked(next, curr);
             }
         }
         let tail = &nodes[nodes.len() - 1];
@@ -77,8 +77,8 @@ impl<T> From<Vec<T>> for List<T> {
         tail.borrow_mut().next = Some(Rc::clone(head));
         head.borrow_mut().prev = Some(Rc::clone(tail));
         unsafe {
-            Rc::adopt(tail, head);
-            Rc::adopt(head, tail);
+            Rc::adopt_unchecked(tail, head);
+            Rc::adopt_unchecked(head, tail);
         }
 
         let head = Rc::clone(head);

--- a/tests/leak_fully_connected_graph.rs
+++ b/tests/leak_fully_connected_graph.rs
@@ -22,7 +22,7 @@ fn fully_connected_graph(count: usize) -> Vec<Rc<RefCell<Node<String>>>> {
         for right in &nodes {
             let link = Rc::clone(right);
             unsafe {
-                Rc::adopt(left, &link);
+                Rc::adopt_unchecked(left, &link);
             }
             left.borrow_mut().links.push(link);
         }

--- a/tests/leak_mutually_adopted.rs
+++ b/tests/leak_mutually_adopted.rs
@@ -14,8 +14,8 @@ fn leak_mutually_adopted() {
     let first = Rc::new(s.clone());
     let last = Rc::new(s);
     unsafe {
-        Rc::adopt(&first, &last);
-        Rc::adopt(&last, &first);
+        Rc::adopt_unchecked(&first, &last);
+        Rc::adopt_unchecked(&last, &first);
     }
     drop(first);
     drop(last);

--- a/tests/leak_self_referential_collection_strong.rs
+++ b/tests/leak_self_referential_collection_strong.rs
@@ -24,7 +24,7 @@ fn leak_self_referential_collection_strong() {
     for _ in 1..10 {
         let clone = Rc::clone(&vec);
         unsafe {
-            Rc::adopt(&vec, &clone);
+            Rc::adopt_unchecked(&vec, &clone);
         }
         vec.borrow_mut().inner.push(clone);
     }

--- a/tests/leak_self_referential_collection_weak.rs
+++ b/tests/leak_self_referential_collection_weak.rs
@@ -25,7 +25,7 @@ fn leak_self_referential_collection_weak() {
     for _ in 1..10 {
         vec.borrow_mut().inner.push(Rc::downgrade(&vec));
         unsafe {
-            Rc::adopt(&vec, &vec);
+            Rc::adopt_unchecked(&vec, &vec);
         }
     }
     let borrow = vec.borrow();

--- a/tests/weak.rs
+++ b/tests/weak.rs
@@ -17,7 +17,7 @@ fn weak() {
     for _ in 0..10 {
         let item = Rc::clone(&array);
         unsafe {
-            Rc::adopt(&array, &item);
+            Rc::adopt_unchecked(&array, &item);
         }
         array.borrow_mut().buffer.push(item);
     }

--- a/tests/weak_upgrade_returns_none_when_cycle_is_deallocated.rs
+++ b/tests/weak_upgrade_returns_none_when_cycle_is_deallocated.rs
@@ -24,7 +24,7 @@ fn weak_upgrade_returns_none_when_cycle_is_deallocated() {
     for _ in 0..10 {
         let clone = Rc::clone(&vec);
         unsafe {
-            Rc::adopt(&vec, &clone);
+            Rc::adopt_unchecked(&vec, &clone);
         }
         vec.borrow_mut().inner.push(clone);
     }


### PR DESCRIPTION
I got some feedback that it is not clear why `Adopt::adopt` needs `unsafe` to call:

- https://users.rust-lang.org/t/cactusref-cycle-aware-reference-counting/61114/2?u=lopopolo
- https://www.reddit.com/r/rust/comments/nzq7l6/cactusref_an_experimental_cycleaware_rc_and_mini/h1r3lxj/

Long term, I intend to explore some alternative APIs to enable safe adoption, but for now, let's rename `adopt` to `adopt_unchecked` while we search for the safer API.