### PR TITLE
Implement `box_free` with `alloc::alloc::dealloc`

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,6 @@ drop(right);
 CactusRef is experimental. This crate has several limitations:
 
 - CactusRef is nightly only.
-- CactusRef reimplements several `alloc` internals which means it may not be
-  safe to use on newer nightly versions than `nightly-2021-06-13`.
 - Cycle detection requires [unsafe code][adopt-api] to use.
 
 CactusRef is a non-trivial extension to `std::rc::Rc` and has not been proven to

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly-2021-06-13
+nightly

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,19 +39,13 @@
 //! # Nightly
 //!
 //! CactusRef depends on several unstable Rust features and can only be built
-//! on a nightly toolchain. CactusRef reimplements several compiler internals
-//! from [alloc], which means it is only safe to build CactusRef with the same
-//! nightly compiler as the one pinned in its `rust-toolchain` file.
-//!
-//! [alloc]: https://doc.rust-lang.org/stable/alloc/
+//! on a nightly toolchain.
 //!
 //! # Maturity
 //!
 //! CactusRef is experimental. This crate has several limitations:
 //!
 //! - CactusRef is nightly only.
-//! - CactusRef reimplements several `alloc` internals which means it may not be
-//!   safe to use on newer nightly versions than `nightly-2021-06-13`.
 //! - Cycle detection requires [unsafe code][adopt-api] to use.
 //!
 //! CactusRef is a non-trivial extension to `std::rc::Rc` and has not been


### PR DESCRIPTION
CactusRef assumes the global allocator for both `Box`es and `Rc`s that
it allocates. This means we can use the stabilized
`alloc::alloc::dealloc` to free any allocated `Box` as long as we
compute the correct layout for `T`.

See https://users.rust-lang.org/t/cactusref-cycle-aware-reference-counting/61114/4

This change allows loosening the restrictions on the nightly compiler
version used. The embedded `rust-toolchain` file now pins only to the
latest nightly. This change ensures CI will always run tests with the
latest nightly compiler.