### PR TITLE
Remove `unsafe` marker from `Adopt::unadopt`

### DIFF
--- a/src/doc/implementing_self_referential_data_structures.rs
+++ b/src/doc/implementing_self_referential_data_structures.rs
@@ -28,10 +28,9 @@
 //!         let tail = head.borrow_mut().prev.take();
 //!         let next = head.borrow_mut().next.take();
 //!         if let Some(ref tail) = tail {
-//!             unsafe {
-//!                 Rc::unadopt(&head, tail);
-//!                 Rc::unadopt(tail, &head);
-//!             }
+//!             Rc::unadopt(&head, tail);
+//!             Rc::unadopt(tail, &head);
+//!
 //!             tail.borrow_mut().next = next.as_ref().map(Rc::clone);
 //!             if let Some(ref next) = next {
 //!                 unsafe {
@@ -40,10 +39,9 @@
 //!             }
 //!         }
 //!         if let Some(ref next) = next {
-//!             unsafe {
-//!                 Rc::unadopt(&head, next);
-//!                 Rc::unadopt(next, &head);
-//!             }
+//!             Rc::unadopt(&head, next);
+//!             Rc::unadopt(next, &head);
+//!
 //!             next.borrow_mut().prev = tail.as_ref().map(Rc::clone);
 //!             if let Some(ref tail) = tail {
 //!                 unsafe {

--- a/tests/leak_doubly_linked_list.rs
+++ b/tests/leak_doubly_linked_list.rs
@@ -22,10 +22,9 @@ impl<T> List<T> {
         let tail = head.borrow_mut().prev.take();
         let next = head.borrow_mut().next.take();
         if let Some(ref tail) = tail {
-            unsafe {
-                Rc::unadopt(&head, tail);
-                Rc::unadopt(tail, &head);
-            }
+            Rc::unadopt(&head, tail);
+            Rc::unadopt(tail, &head);
+
             tail.borrow_mut().next = next.as_ref().map(Rc::clone);
             if let Some(ref next) = next {
                 unsafe {
@@ -34,10 +33,9 @@ impl<T> List<T> {
             }
         }
         if let Some(ref next) = next {
-            unsafe {
-                Rc::unadopt(&head, next);
-                Rc::unadopt(next, &head);
-            }
+            Rc::unadopt(&head, next);
+            Rc::unadopt(next, &head);
+
             next.borrow_mut().prev = tail.as_ref().map(Rc::clone);
             if let Some(ref tail) = tail {
                 unsafe {

--- a/tests/leak_unadopt.rs
+++ b/tests/leak_unadopt.rs
@@ -1,0 +1,57 @@
+#![warn(clippy::all)]
+#![warn(clippy::pedantic)]
+
+use std::cell::RefCell;
+
+use cactusref::{Adopt, Rc};
+
+struct S {
+    inner: Option<Rc<RefCell<S>>>,
+}
+
+fn main() {
+    env_logger::Builder::from_env("CACTUS_LOG").init();
+}
+
+#[test]
+fn leak_unadopt() {
+    log::info!("unadopt");
+
+    let mut first = S { inner: None };
+    let second = S { inner: None };
+    let second = Rc::new(RefCell::new(second));
+
+    first.inner = Some(Rc::clone(&second));
+    let first = Rc::new(RefCell::new(first));
+    unsafe {
+        Rc::adopt_unchecked(&first, &second);
+    }
+
+    let inner = first.borrow_mut().inner.take().unwrap();
+    for _ in 0..10 {
+        Rc::unadopt(&first, &inner);
+    }
+
+    drop(inner);
+    drop(first);
+}
+
+#[test]
+fn leak_with_elided_unadopt() {
+    log::info!("unadopt");
+
+    let mut first = S { inner: None };
+    let second = S { inner: None };
+    let second = Rc::new(RefCell::new(second));
+
+    first.inner = Some(Rc::clone(&second));
+    let first = Rc::new(RefCell::new(first));
+    unsafe {
+        Rc::adopt_unchecked(&first, &second);
+    }
+
+    let inner = first.borrow_mut().inner.take().unwrap();
+
+    drop(inner);
+    drop(first);
+}


### PR DESCRIPTION
Failing to unadopt an `Rc` once it is removed from the cycle is not
unsafe; it causes the graph of `Rc`s to think it is reachable when it is
not. This will result in a leak, which is safe Rust, rather than
unsoundness.

This was discussed on Reddit and looks right to me: https://www.reddit.com/r/rust/comments/nzq7l6/cactusref_an_experimental_cycleaware_rc_and_mini/h1r3lxj/