### PR TITLE
[WIP] Experiment with a safe adoption API

### DIFF
--- a/src/adopt.rs
+++ b/src/adopt.rs
@@ -38,6 +38,7 @@ pub unsafe trait Adopt: sealed::Sealed {
     /// The smart pointer's inner owned value.
     type Inner;
 
+    /// TODO: document me!
     fn adopt(this: &mut Self, other: &Self)
     where
         Self::Inner: Trace;
@@ -90,6 +91,7 @@ unsafe impl<T> Adopt for Rc<T> {
     /// `T`.
     type Inner = T;
 
+    /// TODO: document me!
     fn adopt(this: &mut Self, other: &Self)
     where
         Self::Inner: Trace,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,6 +139,7 @@ mod drop;
 mod hash;
 mod link;
 mod rc;
+mod trace;
 
 // Doc modules
 #[cfg(any(doctest, docsrs))]
@@ -149,6 +150,7 @@ pub mod implementing_self_referential_data_structures;
 pub use adopt::Adopt;
 pub use rc::Rc;
 pub use rc::Weak;
+pub use trace::Trace;
 
 /// Cactus alias for [`Rc`].
 pub type CactusRef<T> = Rc<T>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,6 +148,7 @@ mod trace;
 pub mod implementing_self_referential_data_structures;
 
 pub use adopt::Adopt;
+pub use adopt::AdoptError;
 pub use rc::Rc;
 pub use rc::Weak;
 pub use trace::Trace;

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -5,5 +5,5 @@ pub trait Trace: Sized {
     /// TODO: document me!
     fn yield_owned_rcs<F>(&self, mark: F)
     where
-        F: for<'a> FnMut(&'a mut Rc<Self>);
+        F: FnMut(&mut Rc<Self>);
 }

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -1,6 +1,8 @@
 use crate::rc::Rc;
 
+/// TODO: document me!
 pub trait Trace: Sized {
+    /// TODO: document me!
     fn yield_owned_rcs<F>(&self, mark: F)
     where
         F: for<'a> FnMut(&'a mut Rc<Self>);

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -1,0 +1,7 @@
+use crate::rc::Rc;
+
+pub trait Trace: Sized {
+    fn yield_owned_rcs<F>(&self, mark: F)
+    where
+        F: for<'a> FnMut(&'a mut Rc<Self>);
+}

--- a/tests/leak_doubly_linked_list.rs
+++ b/tests/leak_doubly_linked_list.rs
@@ -37,7 +37,7 @@ struct Node<T> {
 impl<T> Trace for NodeCell<T> {
     fn yield_owned_rcs<F>(&self, mut mark: F)
     where
-        F: for<'a> FnMut(&'a mut Rc<Self>),
+        F: FnMut(&mut Rc<Self>),
     {
         if let Some(ref mut prev) = self.borrow_mut().prev {
             mark(prev);

--- a/tests/leak_doubly_linked_list.rs
+++ b/tests/leak_doubly_linked_list.rs
@@ -1,48 +1,83 @@
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
 #![allow(clippy::shadow_unrelated)]
+#![forbid(unsafe_code)]
 
-use cactusref::{Adopt, Rc};
+use cactusref::{Adopt, Rc, Trace};
 use core::cell::RefCell;
 use core::iter;
+use core::ops::Deref;
+
+struct NodeCell<T>(RefCell<Node<T>>);
+
+impl<T> NodeCell<T> {
+    fn new(data: T) -> Self {
+        Self(RefCell::new(Node {
+            prev: None,
+            next: None,
+            data,
+        }))
+    }
+}
+
+impl<T> Deref for NodeCell<T> {
+    type Target = RefCell<Node<T>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 struct Node<T> {
-    pub prev: Option<Rc<RefCell<Self>>>,
-    pub next: Option<Rc<RefCell<Self>>>,
+    pub prev: Option<Rc<NodeCell<T>>>,
+    pub next: Option<Rc<NodeCell<T>>>,
     pub data: T,
 }
 
+impl<T> Trace for NodeCell<T> {
+    fn yield_owned_rcs<F>(&self, mut mark: F)
+    where
+        F: for<'a> FnMut(&'a mut Rc<Self>),
+    {
+        if let Some(ref mut prev) = self.borrow_mut().prev {
+            mark(prev);
+        }
+        if let Some(ref mut next) = self.borrow_mut().next {
+            mark(next);
+        }
+    }
+}
+
 struct List<T> {
-    pub head: Option<Rc<RefCell<Node<T>>>>,
+    pub head: Option<Rc<NodeCell<T>>>,
 }
 
 impl<T> List<T> {
-    fn pop(&mut self) -> Option<Rc<RefCell<Node<T>>>> {
+    fn pop(&mut self) -> Option<Rc<NodeCell<T>>> {
         let head = self.head.take()?;
-        let tail = head.borrow_mut().prev.take();
-        let next = head.borrow_mut().next.take();
-        if let Some(ref tail) = tail {
+        let mut tail = head.borrow_mut().prev.take();
+        let mut next = head.borrow_mut().next.take();
+
+        if let Some(ref mut tail) = tail {
             Rc::unadopt(&head, tail);
             Rc::unadopt(tail, &head);
 
             tail.borrow_mut().next = next.as_ref().map(Rc::clone);
             if let Some(ref next) = next {
-                unsafe {
-                    Rc::adopt_unchecked(tail, next);
-                }
+                Rc::adopt(tail, next);
             }
         }
-        if let Some(ref next) = next {
+
+        if let Some(ref mut next) = next {
             Rc::unadopt(&head, next);
             Rc::unadopt(next, &head);
 
             next.borrow_mut().prev = tail.as_ref().map(Rc::clone);
             if let Some(ref tail) = tail {
-                unsafe {
-                    Rc::adopt_unchecked(next, tail);
-                }
+                Rc::adopt(next, tail);
             }
         }
+
         self.head = next;
         Some(head)
     }
@@ -50,34 +85,35 @@ impl<T> List<T> {
 
 impl<T> From<Vec<T>> for List<T> {
     fn from(list: Vec<T>) -> Self {
-        let nodes = list
+        if list.is_empty() {
+            return Self { head: None };
+        }
+        let mut nodes = list
             .into_iter()
-            .map(|data| {
-                Rc::new(RefCell::new(Node {
-                    prev: None,
-                    next: None,
-                    data,
-                }))
-            })
+            .map(|data| Rc::new(NodeCell::new(data)))
             .collect::<Vec<_>>();
+
         for i in 0..nodes.len() - 1 {
-            let curr = &nodes[i];
-            let next = &nodes[i + 1];
-            curr.borrow_mut().next = Some(Rc::clone(next));
-            next.borrow_mut().prev = Some(Rc::clone(curr));
-            unsafe {
-                Rc::adopt_unchecked(curr, next);
-                Rc::adopt_unchecked(next, curr);
-            }
+            let next = Rc::clone(&nodes[i + 1]);
+            let curr = &mut nodes[i];
+            curr.borrow_mut().next = Some(Rc::clone(&next));
+            Rc::adopt(curr, &next);
+
+            let curr = Rc::clone(&nodes[i]);
+            let next = &mut nodes[i + 1];
+            next.borrow_mut().prev = Some(Rc::clone(&curr));
+            Rc::adopt(next, &curr);
         }
-        let tail = &nodes[nodes.len() - 1];
-        let head = &nodes[0];
-        tail.borrow_mut().next = Some(Rc::clone(head));
-        head.borrow_mut().prev = Some(Rc::clone(tail));
-        unsafe {
-            Rc::adopt_unchecked(tail, head);
-            Rc::adopt_unchecked(head, tail);
-        }
+
+        let head = Rc::clone(&nodes[0]);
+        let tail = nodes.last_mut().unwrap();
+        tail.borrow_mut().next = Some(Rc::clone(&head));
+        Rc::adopt(tail, &head);
+
+        let tail = Rc::clone(&nodes[nodes.len() - 1]);
+        let head = &mut nodes[0];
+        head.borrow_mut().prev = Some(Rc::clone(&tail));
+        Rc::adopt(head, &tail);
 
         let head = Rc::clone(head);
         Self { head: Some(head) }
@@ -95,10 +131,12 @@ fn leak_doubly_linked_list() {
         .take(10)
         .collect::<Vec<_>>();
     let mut list = List::from(list);
+
     let head = list.pop().unwrap();
     assert!(head.borrow().data.starts_with('a'));
     assert_eq!(Rc::strong_count(&head), 1);
     assert_eq!(list.head.as_ref().map(Rc::strong_count), Some(3));
+
     let weak = Rc::downgrade(&head);
     drop(head);
     assert!(weak.upgrade().is_none());


### PR DESCRIPTION
This PR experiments with a safe `Adopt::adopt` API.

The API requires that the inner `T` of and `Rc<T>` implement a new trait, `Trace`. `Trace` has a single required method: `Trace::mark`. `Rc::<T>::adopt` is only available when `T` impls `Trace`.

`Trace::mark` allows a `T` to use internal iteration to mark all of the `Rc<T>`s that are immediately reachable. `Rc::<T>::adopt` determines whether an adoption of `other` is safe based on whether `T` yields a `&mut Rc<T>` that points to the same allocation as the given other `Rc` to adopt.

By yielding a `&mut Rc<T>`, `T` proves that it owns an `Rc<T>` that points to the same allocation as `other`, which satisfies the safety invariants of `Adopt::adopt_unchecked`.

Practically, `T`s that implement `Trace` must use some sort of interior mutability, since `Trace::mark` takes `&self`.

The doubly linked list integration test is updated to use this new safe `adopt` API and impls `Trace`. The orphan rule for trait impls complicates implementing `Trace` for `Rc<RefCell<T>>` and requires the introduction of a wrapper type. The doubly linked list test now has `#![forbid(unsafe_code)]`.

r? @tummychow