### PR TITLE
Reduce unsoundness surface by using Layout::for_value_raw

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
     allocator_api,
     core_intrinsics,
     dropck_eyepatch,
+    layout_for_ptr,
     set_ptr_value,
     slice_ptr_get
 )]


### PR DESCRIPTION
In all places where CactusRef calls `Layout::for_value`, we already have
a `NonNull<T>`. Replacing these calls with `Layout::for_value_raw`
avoids creating an intermediate reference when we don't have to, which
can help prevent aliasing issues by avoiding them entirely.

This change is made in `Weak::drop` and all variants of `Rc::drop`.

This commit adds an additional nightly feature: `layout_for_ptr`.

Thanks @CAD97 for suggesting this change in https://github.com/artichoke/cactusref/pull/45#discussion_r652021760.