### PR TITLE
Fix clippy violation for redundant-closure-for-method-calls on latest nightly

### DIFF
--- a/src/rc.rs
+++ b/src/rc.rs
@@ -388,7 +388,7 @@ impl<T> Rc<T> {
             Rc::from_ptr(Rc::allocate_for_layout(
                 Layout::new::<T>(),
                 |layout| Global.allocate(layout),
-                |mem| mem.cast::<RcBox<MaybeUninit<T>>>(),
+                <*mut u8>::cast,
             ))
         }
     }


### PR DESCRIPTION
The clippy suggestion caused an error. I reported this upstream: https://github.com/rust-lang/rust-clippy/issues/7746.