### PR TITLE
Update Cargo.toml manifest version and docs.rs metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ default = ["std"]
 std = []
 
 [dependencies]
-hashbrown = { version = "0.12", default-features = false, features = ["inline-more"] }
+hashbrown = { version = "0.12.0", default-features = false, features = ["inline-more"] }
 log = "0.4.6"
-rustc-hash = { version = "1.1", default-features = false }
+rustc-hash = { version = "1.1.0", default-features = false }
 
 [dev-dependencies]
 # Enable debug and trace-level logging in tests.
@@ -38,5 +38,6 @@ features = ["markdown_deps_updated", "html_root_url_updated"]
 [package.metadata.docs.rs]
 # This sets the default target to `x86_64-unknown-linux-gnu` and only builds
 # that target. `cactusref` has the same API and code on all targets.
-targets = ["x86_64-unknown-linux-gnu"]
+default-target = "x86_64-unknown-linux-gnu"
+targets = []
 rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
- Use precise versions for dependencies. See:
  https://users.rust-lang.org/t/psa-please-specify-precise-dependency-versions-in-cargo-toml/71277
- Use the same style of docs.rs metadata as used in
  artichoke/raw-parts#24.