### PR TITLE
Update `Rc` for latest nightly, release v0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cactusref"
-version = "0.1.1" # remember to set `html_root_url` in `src/lib.rs`.
+version = "0.2.0" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT"
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-cactusref = "0.1.1"
+cactusref = "0.2.0"
 ```
 
 CactusRef is mostly a drop-in replacement for `std::rc::Rc`, which can be used

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,7 @@
 //!
 //! [`std::rc::Rc`]: https://doc.rust-lang.org/stable/std/rc/struct.Rc.html
 
-#![doc(html_root_url = "https://docs.rs/cactusref/0.1.1")]
+#![doc(html_root_url = "https://docs.rs/cactusref/0.2.0")]
 #![no_std]
 
 // Ensure code blocks in README.md compile

--- a/src/rc.rs
+++ b/src/rc.rs
@@ -586,7 +586,9 @@ impl<T> Rc<T> {
         let offset = data_offset(ptr);
 
         // Reverse the offset to find the original RcBox.
-        let rc_ptr = (ptr as *mut RcBox<T>).set_ptr_value((ptr as *mut u8).offset(-offset));
+        let rc_ptr = (ptr as *mut u8)
+            .offset(-offset)
+            .with_metadata_of(ptr as *mut RcBox<T>);
 
         Self::from_ptr(rc_ptr)
     }
@@ -981,7 +983,7 @@ impl<T> Rc<T> {
         Self::allocate_for_layout(
             Layout::for_value(&*ptr),
             |layout| Global.allocate(layout),
-            |mem| (ptr as *mut RcBox<T>).set_ptr_value(mem),
+            |mem| mem.with_metadata_of(ptr as *mut RcBox<T>),
         )
     }
 
@@ -1509,7 +1511,9 @@ impl<T> Weak<T> {
             let offset = data_offset(ptr);
             // Thus, we reverse the offset to get the whole RcBox.
             // SAFETY: the pointer originated from a Weak, so this offset is safe.
-            (ptr as *mut RcBox<T>).set_ptr_value((ptr as *mut u8).offset(-offset))
+            (ptr as *mut u8)
+                .offset(-offset)
+                .with_metadata_of(ptr as *mut RcBox<T>)
         };
 
         // SAFETY: we now have recovered the original Weak pointer, so can create the Weak.


### PR DESCRIPTION
rust-lang/rust#95249 reworked the `ptr::set_ptr_value` API. The new API
is called `ptr::with_metadata_of`. This PR syncs this crate's `Rc` impl
with upstream.

This nightly breakage means a new semver incompatible version bump is
due.