### PR TITLE
Fix rendering of `Option<Rc<T>>` in `Weak` docs

### DIFF
--- a/src/rc.rs
+++ b/src/rc.rs
@@ -1298,7 +1298,7 @@ impl<T> From<Box<T>> for Rc<T> {
 
 /// `Weak` is a version of [`Rc`] that holds a non-owning reference to the
 /// managed allocation. The allocation is accessed by calling [`upgrade`] on the `Weak`
-/// pointer, which returns an [`Option`]`<`[`Rc`]`<T>>`.
+/// pointer, which returns an <code>[Option]<[Rc]\<T>></code>.
 ///
 /// Since a `Weak` reference does not count towards ownership, it will not
 /// prevent the value stored in the allocation from being dropped, and `Weak` itself makes no


### PR DESCRIPTION
## Screenshots

### Before

<img width="705" alt="Screen Shot 2022-10-02 at 2 47 18 PM" src="https://user-images.githubusercontent.com/860434/193477739-037f57ff-43d5-44b8-a8b4-b7bc70b5ec10.png">

### After

<img width="700" alt="Screen Shot 2022-10-02 at 2 47 29 PM" src="https://user-images.githubusercontent.com/860434/193477744-5a468c3d-1ea3-4152-b73f-3978993ea32e.png">