### PR TITLE
Fix bitrot

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -22,10 +22,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: artichoke/setup-rust/build-and-test@v1
         with:
-          profile: minimal
-          override: true
+          toolchain: nightly
 
       - name: Compile
         run: cargo build --verbose

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,13 +17,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        include:
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-          - os: windows-latest
-            target: x86_64-pc-windows-msvc
-          - os: macos-latest
-            target: x86_64-apple-darwin
     env:
       RUSTFLAGS: -D warnings
       RUST_BACKTRACE: 1
@@ -50,19 +43,6 @@ jobs:
 
       - name: Test with no default features
         run: cargo test --no-default-features
-
-      - name: Install nightly Rust toolchain
-        if: matrix.target == 'aarch64-unknown-linux-gnu' || matrix.target == 'x86_64-apple-darwin' || matrix.target == 'x86_64-unknown-linux-gnu'
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          target: ${{ matrix.target }}
-
-      - name: Test with leak sanitizer and all features
-        if: matrix.target == 'aarch64-unknown-linux-gnu' || matrix.target == 'x86_64-apple-darwin' || matrix.target == 'x86_64-unknown-linux-gnu'
-        run: cargo test --all-features --target ${{ matrix.target }}
-        env:
-          RUSTFLAGS: "-Z sanitizer=leak"
 
   build_x86:
     name: Build 32-bit
@@ -107,6 +87,35 @@ jobs:
 
       - name: Test with no default features
         run: cargo test --no-default-features --target ${{ matrix.target }}
+
+  leaksan:
+    name: Leak sanitizer
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+    env:
+      RUSTFLAGS: -D warnings
+      RUST_BACKTRACE: 1
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Rust toolchain
+        uses: artichoke/setup-rust/build-and-test@v1
+        with:
+          toolchain: nightly
+          target: ${{ matrix.target }}
+
+      - name: Test with leak sanitizer and all features
+        run: cargo test --all-features --target ${{ matrix.target }}
+        env:
+          RUSTFLAGS: "-Z sanitizer=leak"
 
   rust:
     name: Lint and format Rust

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,9 +32,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: artichoke/setup-rust/build-and-test@v1
         with:
-          profile: minimal
+          toolchain: nightly
 
       - name: Compile
         run: cargo build --verbose
@@ -84,9 +84,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: artichoke/setup-rust/build-and-test@v1
         with:
-          profile: minimal
+          toolchain: nightly
           target: ${{ matrix.target }}
 
       - name: Install 32-bit platform support
@@ -119,19 +119,15 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: artichoke/setup-rust/lint-and-format@v1
         with:
-          profile: minimal
-          components: rustfmt, clippy
+          toolchain: nightly
 
       - name: Check formatting
-        run: cargo fmt -- --check --color=auto
+        run: cargo fmt --check
 
       - name: Lint with Clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features --all-targets
+        run: cargo clippy --workspace --all-features --all-targets
 
   ruby:
     name: Lint and format Ruby

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.2.0" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT"
 edition = "2021"
+rust-version = "1.56.0"
 readme = "README.md"
 repository = "https://github.com/artichoke/cactusref"
 documentation = "https://docs.rs/cactusref"


### PR DESCRIPTION
Get CI passing again and remove dependencies on actions-rs GitHub Actions.

CI has been red since October 11, 2022.