### PR TITLE
Use stricter version pinning for GitHub Actions

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.2
 
       - name: Install Ruby toolchain
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@6cecb48364174b0952995175c55f9bf5527e6682 # v1.147.0
         with:
           ruby-version: ".ruby-version"
           bundler-cache: true
@@ -41,10 +41,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.2
 
       - name: Install Rust toolchain
-        uses: artichoke/setup-rust/audit@v1
+        uses: artichoke/setup-rust/audit@v1.9.0
 
       - name: Generate Cargo.lock
         run: |
@@ -52,7 +52,7 @@ jobs:
             cargo generate-lockfile --verbose
           fi
 
-      - uses: EmbarkStudios/cargo-deny-action@v1
+      - uses: EmbarkStudios/cargo-deny-action@e0a440755b184aa50374330fa75cca0f84fcb59a # v1.5.2
         with:
           arguments: --locked --all-features
           command: check ${{ matrix.checks }}

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.2
 
       - name: Install Rust toolchain
-        uses: artichoke/setup-rust/build-and-test@v1
+        uses: artichoke/setup-rust/build-and-test@v1.9.0
         with:
           toolchain: nightly
 

--- a/.github/workflows/block-merge.yaml
+++ b/.github/workflows/block-merge.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: mheap/github-action-required-labels@v3
+      - uses: mheap/github-action-required-labels@422e4c352ef83db91089e6acfbf09d8725e08abc # v4.0.0
         with:
           mode: exactly
           count: 0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,10 +22,10 @@ jobs:
       RUST_BACKTRACE: 1
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.2
 
       - name: Install Rust toolchain
-        uses: artichoke/setup-rust/build-and-test@v1
+        uses: artichoke/setup-rust/build-and-test@v1.9.0
         with:
           toolchain: nightly
 
@@ -61,10 +61,10 @@ jobs:
       RUST_BACKTRACE: 1
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.2
 
       - name: Install Rust toolchain
-        uses: artichoke/setup-rust/build-and-test@v1
+        uses: artichoke/setup-rust/build-and-test@v1.9.0
         with:
           toolchain: nightly
           target: ${{ matrix.target }}
@@ -104,10 +104,10 @@ jobs:
       RUST_BACKTRACE: 1
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.2
 
       - name: Install Rust toolchain
-        uses: artichoke/setup-rust/build-and-test@v1
+        uses: artichoke/setup-rust/build-and-test@v1.9.0
         with:
           toolchain: nightly
           target: ${{ matrix.target }}
@@ -125,10 +125,10 @@ jobs:
       RUST_BACKTRACE: 1
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.2
 
       - name: Install Rust toolchain
-        uses: artichoke/setup-rust/lint-and-format@v1
+        uses: artichoke/setup-rust/lint-and-format@v1.9.0
         with:
           toolchain: nightly
 
@@ -143,10 +143,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.2
 
       - name: Install Ruby toolchain
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@6cecb48364174b0952995175c55f9bf5527e6682 # v1.147.0
         with:
           ruby-version: ".ruby-version"
           bundler-cache: true
@@ -159,7 +159,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.2
 
       - name: Format with prettier
         run: npx prettier --check '**/*'

--- a/.github/workflows/markdown-link-check.yaml
+++ b/.github/workflows/markdown-link-check.yaml
@@ -23,10 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.2
 
       - name: Check for broken links in markdown files
-        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        uses: gaurav-nelson/github-action-markdown-link-check@d53a906aa6b22b8979d33bc86170567e619495ec # v1.0.15
         with:
           use-quiet-mode: "yes"
           use-verbose-mode: "yes"

--- a/.github/workflows/miri.yaml
+++ b/.github/workflows/miri.yaml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.2
 
       - name: Install Rust toolchain
-        uses: artichoke/setup-rust/miri@v1
+        uses: artichoke/setup-rust/miri@v1.9.0
         with:
           toolchain: nightly
 

--- a/.github/workflows/repo-labels.yaml
+++ b/.github/workflows/repo-labels.yaml
@@ -20,10 +20,10 @@ jobs:
     name: Synchronize repository labels
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.5.2
 
       - name: Sync GitHub Issue Labels
-        uses: crazy-max/ghaction-github-labeler@v4
+        uses: crazy-max/ghaction-github-labeler@3de87da19416edc45c90cd89e7a4ea922a3aae5a # v4.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           yaml-file: .github/labels.yaml

--- a/.github/workflows/rustdoc.yaml
+++ b/.github/workflows/rustdoc.yaml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.2
 
       - name: Install Rust toolchain
-        uses: artichoke/setup-rust/rustdoc@v1
+        uses: artichoke/setup-rust/rustdoc@v1.9.0
 
       - name: Check docs with no default features
         run: cargo doc --workspace --no-default-features
@@ -38,7 +38,7 @@ jobs:
         run: cargo doc --workspace
 
       - name: Deploy Docs
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3.9.2
         if: github.ref == 'refs/heads/trunk'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Pin actions from the @actions and @artichoke orgs with full git tags. Pin all other actions with git SHA corresponding to a tag.